### PR TITLE
Bugfix/refactor tests

### DIFF
--- a/pybites_challenges/1/test_bite_1.py
+++ b/pybites_challenges/1/test_bite_1.py
@@ -1,4 +1,4 @@
-from pybites_challenges.bite_1 import sum_numbers
+from bite_1 import sum_numbers
 
 
 def test_sum_numbers_default_args():

--- a/pybites_challenges/15/test_bite_15.py
+++ b/pybites_challenges/15/test_bite_15.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pybites_challenges.bite_15 import enumerate_names_countries
+from bite_15 import enumerate_names_countries
 
 expected_lines = [
     "1. Julian     Australia",

--- a/pybites_challenges/16/test_bite_16.py
+++ b/pybites_challenges/16/test_bite_16.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from itertools import islice
 
-from pybites_challenges.bite_16 import gen_special_pybites_dates
+from bite_16 import gen_special_pybites_dates
 
 
 def test_gen_special_pybites_dates():

--- a/pybites_challenges/26/test_bite_26.py
+++ b/pybites_challenges/26/test_bite_26.py
@@ -1,6 +1,6 @@
 # Test for Bite 26:
 
-from pybites_challenges.bite_26 import *
+from bite_26 import *
 
 
 def test_filter_bites_default_arguments():

--- a/pybites_challenges/37/test_bite_37.py
+++ b/pybites_challenges/37/test_bite_37.py
@@ -2,7 +2,7 @@
 
 import inspect
 
-from pybites_challenges.bite_37 import *
+from bite_37 import *
 
 expected = """10
 9

--- a/pybites_challenges/5/test_bite_5.py
+++ b/pybites_challenges/5/test_bite_5.py
@@ -1,4 +1,4 @@
-from pybites_challenges.bite_5 import (
+from bite_5 import (
     NAMES,
     dedup_and_title_case_names,
     sort_by_surname_desc,

--- a/pybites_challenges/8/test_bite_8.py
+++ b/pybites_challenges/8/test_bite_8.py
@@ -1,4 +1,4 @@
-from pybites_challenges.bite_8 import rotate
+from bite_8 import rotate
 
 
 def test_small_rotate():

--- a/utils/create_files.py
+++ b/utils/create_files.py
@@ -7,41 +7,40 @@ import argparse
 from pathlib import PosixPath as _path
 from os import system as do
 
-parser = argparse.ArgumentParser(
-    description="""Provide the bite number
-    to create the bite.py file and test_bite.py file"""
-)
 
-parser.add_argument(
-    "-n",
-    metavar="--bite-number",
-    required=True,
-    type=int,
-    help="The number of the exercise as found on codechalleng.es",
-)
-
-args = parser.parse_args()
-
-
-def make_files(num):
+def make_files(num: int) -> None:
     starting_dir = _path(_path.cwd())
 
-    # Creates the path object for the pytest file then creates the file
-    test_file = starting_dir.joinpath("tests", f"test_bite_{num}")
-    with open(test_file, "w+") as wt:
-        wt.write(
-            f" # Test for Bite {num}: \n\nfrom pybites_challenges.bite_{num} import"
-        )
-    # Creates the path object then makes the directory and bite_num.py file
+    # Creates a path object for the bite_num directory
     bite_path = starting_dir.joinpath("pybites_challenges", str(num))
-    bite_path.mkdir()
-    bite_file = bite_path.joinpath(f"bite_{num}.py")
+    if bite_path.is_dir() is False:
+        bite_path.mkdir()
 
+    bite_file = bite_path.joinpath(f"bite_{num}.py")
     with open(bite_file, "w+") as w:
         w.write(f" # Bite {num}: <name of the challenge>")
 
+    test_file = bite_path.joinpath(f"test_bite_{num}")
+    with open(test_file, "w+") as wt:
+        wt.write(f" # Test for Bite {num}: \n\nfrom bite_{num} import *")
+
 
 def main():
+    parser = argparse.ArgumentParser(
+        description="""Provide the bite number
+    to create the bite.py file and test_bite.py file"""
+    )
+
+    parser.add_argument(
+        "-n",
+        metavar="--bite-number",
+        required=True,
+        type=int,
+        help="The number of the exercise as found on codechalleng.es",
+    )
+
+    args = parser.parse_args()
+
     make_files(args.n)
 
 


### PR DESCRIPTION
### What
- This moves the Pytest files into the individual bite directories that they are written to test. This requires a rewrite of the ```make_files``` function in ```utils/create_files.py``` to create the test files in the correct directories as well.

### Why
- This refactor of the codebase structure is to follow the recommended layout from codechalleng.es so the PyBites Challenge repo can be cloned and allow for uploading of solutions through git instead of the web interface.  This will also allow for easier integration of all of my previously solved challenges  with my own repo. A little extra work now to save me from entering them one by one.